### PR TITLE
Use handler directly instead of slog

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"context"
 	"io"
 	"os"
 	"time"
@@ -10,6 +11,8 @@ import (
 )
 
 const delimiter = "."
+
+var void = context.Background()
 
 func checkIfTerminal(w io.Writer) bool {
 	switch v := w.(type) {


### PR DESCRIPTION
```
[logger]>> benchstat testouille/new.txt testouille/new2.txt
goos: darwin
goarch: amd64
pkg: github.com/mdouchement/logger
cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
             │ testouille/new.txt │         testouille/new2.txt          │
             │       sec/op       │    sec/op     vs base                │
LogrusGELF-8          6.893µ ± 5%   6.693µ ± 14%        ~ (p=0.105 n=10)
SlogGELF-8            5.952µ ± 2%   4.657µ ±  3%  -21.76% (p=0.000 n=10)
LogrusText-8          7.895µ ± 1%   7.638µ ±  0%   -3.26% (p=0.000 n=10)
SlogText-8            7.476µ ± 0%   6.244µ ±  1%  -16.47% (p=0.000 n=10)
geomean               7.015µ        6.209µ        -11.48%

             │ testouille/new.txt │         testouille/new2.txt         │
             │        B/op        │     B/op      vs base               │
LogrusGELF-8         4.482Ki ± 1%   4.487Ki ± 1%       ~ (p=1.000 n=10)
SlogGELF-8           2.639Ki ± 0%   2.429Ki ± 0%  -7.97% (p=0.000 n=10)
LogrusText-8         4.513Ki ± 0%   4.504Ki ± 0%  -0.18% (p=0.000 n=10)
SlogText-8           5.431Ki ± 0%   5.571Ki ± 0%  +2.58% (p=0.000 n=10)
geomean              4.126Ki        4.067Ki       -1.45%

             │ testouille/new.txt │         testouille/new2.txt          │
             │     allocs/op      │ allocs/op   vs base                  │
LogrusGELF-8           65.00 ± 0%   65.00 ± 0%        ~ (p=1.000 n=10) ¹
SlogGELF-8             73.00 ± 0%   63.00 ± 0%  -13.70% (p=0.000 n=10)
LogrusText-8           65.00 ± 0%   65.00 ± 0%        ~ (p=1.000 n=10) ¹
SlogText-8             74.00 ± 0%   64.00 ± 0%  -13.51% (p=0.000 n=10)
geomean                69.12        64.24        -7.05%
¹ all samples are equal
```