### PR TITLE
Fix GELF string escaping

### DIFF
--- a/buffer_gelf.go
+++ b/buffer_gelf.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // A BufferGELF is a buffer used to build GELF payload.
@@ -25,7 +26,7 @@ func NewBufferGELF() *BufferGELF {
 // Host adds the host to the GELF buffer.
 func (b *BufferGELF) Host(h string) {
 	b.key("host")
-	b.buf.WriteString(strconv.QuoteToGraphic(h))
+	b.string(h, true)
 }
 
 // Level adds the level to the GELF buffer.
@@ -42,14 +43,14 @@ func (b *BufferGELF) Message(m string) {
 		// original input. If the input has no newlines, stick the
 		// whole thing in short_message.
 		b.key("short_message")
-		b.buf.WriteString(strconv.QuoteToGraphic(m[:i]))
+		b.string(m[:i], true)
 		b.key("full_message")
-		b.buf.WriteString(strconv.QuoteToGraphic(m))
+		b.string(m, true)
 		return
 	}
 
 	b.key("short_message")
-	b.buf.WriteString(strconv.QuoteToGraphic(m))
+	b.string(m, true)
 }
 
 // Timestamp adds the timestamp to the GELF buffer.
@@ -75,7 +76,7 @@ func (b *BufferGELF) Add(k string, v any) {
 	// otherwise convert if necessary
 	switch value := v.(type) {
 	case time.Time:
-		b.buf.WriteString(strconv.QuoteToGraphic(value.Format(time.RFC3339)))
+		b.string(value.Format(time.RFC3339), true)
 	case uint, uint8, uint16, uint32,
 		int, int8, int16, int32, int64:
 		b.buf.WriteString(fmt.Sprint(value))
@@ -90,9 +91,9 @@ func (b *BufferGELF) Add(k string, v any) {
 	case bool:
 		b.buf.WriteString(fmt.Sprintf(`"%t"`, value))
 	case string:
-		b.buf.WriteString(strconv.QuoteToGraphic(value))
+		b.string(value, true)
 	default:
-		b.buf.WriteString(strconv.QuoteToGraphic(fmt.Sprint(value)))
+		b.string(fmt.Sprint(value), true)
 	}
 }
 
@@ -113,6 +114,308 @@ func (b *BufferGELF) Bytes() []byte {
 
 func (b *BufferGELF) key(k string) {
 	b.buf.WriteString(",")
-	b.buf.WriteString(strconv.QuoteToGraphic(k))
+	b.string(k, true)
 	b.buf.WriteString(":")
+}
+
+// based on https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/encoding/json/encode.go;l=956
+func (b *BufferGELF) string(src string, escapeHTML bool) {
+	buf := b.buf
+	buf.WriteByte('"')
+	start := 0
+	for i := 0; i < len(src); {
+		if b := src[i]; b < utf8.RuneSelf {
+			if htmlSafeSet[b] || (!escapeHTML && safeSet[b]) {
+				i++
+				continue
+			}
+			buf.WriteString(src[start:i])
+			switch b {
+			case '\\', '"':
+				buf.WriteByte('\\')
+				buf.WriteByte(b)
+			case '\b':
+				buf.WriteByte('\\')
+				buf.WriteByte('b')
+			case '\f':
+				buf.WriteByte('\\')
+				buf.WriteByte('f')
+			case '\n':
+				buf.WriteByte('\\')
+				buf.WriteByte('n')
+			case '\r':
+				buf.WriteByte('\\')
+				buf.WriteByte('r')
+			case '\t':
+				buf.WriteByte('\\')
+				buf.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \b, \f, \n, \r and \t.
+				// If escapeHTML is set, it also escapes <, >, and &
+				// because they can lead to security holes when
+				// user-controlled strings are rendered into JSON
+				// and served to some browsers.
+				buf.WriteByte('\\')
+				buf.WriteByte('u')
+				buf.WriteByte('0')
+				buf.WriteByte('0')
+				buf.WriteByte(hex[b>>4])
+				buf.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		// TODO(https://go.dev/issue/56948): Use generic utf8 functionality.
+		// For now, cast only a small portion of byte slices to a string
+		// so that it can be stack allocated. This slows down []byte slightly
+		// due to the extra copy, but keeps string performance roughly the same.
+		n := len(src) - i
+		if n > utf8.UTFMax {
+			n = utf8.UTFMax
+		}
+		c, size := utf8.DecodeRuneInString(string(src[i : i+n]))
+		if c == utf8.RuneError && size == 1 {
+			b.buf.WriteString(src[start:i])
+			b.buf.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See https://en.wikipedia.org/wiki/JSON#Safety.
+		if c == '\u2028' || c == '\u2029' {
+			b.buf.WriteString(src[start:i])
+			b.buf.WriteByte('\\')
+			b.buf.WriteByte('u')
+			b.buf.WriteByte('2')
+			b.buf.WriteByte('0')
+			b.buf.WriteByte('2')
+			b.buf.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	b.buf.WriteString(src[start:])
+	b.buf.WriteByte('"')
+}
+
+const hex = "0123456789abcdef"
+
+// safeSet holds the value true if the ASCII character with the given array
+// position can be represented inside a JSON string without any further
+// escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), and the backslash character ("\").
+var safeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}
+
+// htmlSafeSet holds the value true if the ASCII character with the given
+// array position can be safely represented inside a JSON string, embedded
+// inside of HTML <script> tags, without any additional escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), the backslash character ("\"), HTML opening and closing
+// tags ("<" and ">"), and the ampersand ("&").
+var htmlSafeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      false,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      false,
+	'=':      true,
+	'>':      false,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
 }

--- a/buffer_gelf_test.go
+++ b/buffer_gelf_test.go
@@ -60,4 +60,12 @@ func TestBufferGELF(t *testing.T) {
 	if string(b.Complete(false)) != `{"version":"1.1","_k":42,"_k":43}` {
 		t.Errorf("got: %s", b.Bytes())
 	}
+
+	//
+
+	b = logger.NewBufferGELF()
+	b.Message(string([]byte{162, 98, 107, 50, 251, 64, 64, 184, 81, 235, 133, 30, 184, 99, 107, 101, 121, 24, 42})) // Some CBOR payload
+	if string(b.Complete(false)) != `{"version":"1.1","short_message":"\ufffdbk2\ufffd@@\ufffdQ\ufffd\ufffd\u001e\ufffdckey\u0018*"}` {
+		t.Errorf("got: %s", b.Bytes())
+	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,6 @@
 package logger
 
-// A KeyPrefix is used to tell that en given attr/field is a prefix.
+// KeyPrefix is used to tell that en given attr/field is a prefix.
 const KeyPrefix = "__prefix"
 
 // A Logger is the interface used in this package for logging,

--- a/slog_text_handler.go
+++ b/slog_text_handler.go
@@ -12,6 +12,7 @@ import (
 )
 
 type (
+	// SlogTextOption holds SlogTextHandler's options.
 	SlogTextOption struct {
 		// Set the logger's level.
 		Level slog.Level
@@ -202,6 +203,7 @@ func (h *SlogTextHandler) Handle(_ context.Context, record slog.Record) error {
 	return err
 }
 
+// Clone clones the entry, it creates a new instance and linking the parent to it.
 func (h *SlogTextHandler) Clone() *SlogTextHandler {
 	return &SlogTextHandler{
 		parent:      h,


### PR DESCRIPTION
Fix #11 

Perf improvement too
```
goos: darwin
goarch: amd64
pkg: github.com/mdouchement/logger
cpu: Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
           │ testouille/old.txt │         testouille/new.txt          │
           │       sec/op       │   sec/op     vs base                │
SlogGELF-8          4.915µ ± 5%   3.310µ ± 3%  -32.65% (p=0.000 n=10)

           │ testouille/old.txt │         testouille/new.txt          │
           │        B/op        │     B/op      vs base               │
SlogGELF-8         2.448Ki ± 1%   2.329Ki ± 1%  -4.87% (p=0.000 n=10)

           │ testouille/old.txt │         testouille/new.txt         │
           │     allocs/op      │ allocs/op   vs base                │
SlogGELF-8           63.00 ± 0%   42.00 ± 0%  -33.33% (p=0.000 n=10)
```